### PR TITLE
feat: API poll extractor

### DIFF
--- a/bento_etl/main.py
+++ b/bento_etl/main.py
@@ -29,3 +29,9 @@ app = BentoFastAPI(
 )
 
 app.include_router(job_router)
+
+# Dummy data source router for dev work
+if config.bento_debug:
+    from .routers.test_sources import test_data_source_router
+
+    app.include_router(test_data_source_router)

--- a/bento_etl/routers/test_sources.py
+++ b/bento_etl/routers/test_sources.py
@@ -1,0 +1,34 @@
+import json
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+__all__ = ["test_data_source_router"]
+
+PHENOPACKETS_FILE_PATH = "tests/data/synthetic_phenopackets_v2.json"
+EXPERIMENTS_FILE_PATH = "tests/data/synthetic_experiments.json"
+
+test_data_source_router = APIRouter(prefix="/test/data-sources")
+
+
+@test_data_source_router.get(
+    "/pheno-clean",
+    description="Returns a JSON response with a couple of phenopackets",
+    summary="Dummy API data source for valid phenopackets",
+)
+def get_phenopackets():
+    data = {}
+    with open(PHENOPACKETS_FILE_PATH, mode="rb") as f:
+        data = json.load(f)
+    return JSONResponse(data)
+
+
+@test_data_source_router.get(
+    "/exps-clean",
+    description="Returns a JSON response with a couple of experiments",
+    summary="Dummy API data source for valid experiments",
+)
+def get_experiments():
+    data = {}
+    with open(EXPERIMENTS_FILE_PATH, mode="rb") as f:
+        data = json.load(f)
+    return JSONResponse(data)

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -8,7 +8,7 @@ services:
       - 5000:5000
     environment:
       - BENTO_UID=${UID}
-      - BENTO_DEBUG=False
+      - BENTO_DEBUG=True
       - CORS_ORIGINS="*"
       - BENTO_AUTHZ_SERVICE_URL=""
       - BENTO_AUTHZ_ENABLED=False

--- a/poetry.lock
+++ b/poetry.lock
@@ -709,7 +709,7 @@ version = "1.0.9"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
     {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
@@ -731,7 +731,7 @@ version = "0.28.1"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
     {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
@@ -2094,4 +2094,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<=3.13"
-content-hash = "595cbc93fe05f017a78fd7c323e84b8e35af7568913772ae4a40872cfb9ca2e6"
+content-hash = "96952cf40ea819d633643a41035d6fd9a496f0eabe535b38cb7b282ab8a22211"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
     "pydantic-settings (>=2.9.1,<3.0.0)",
     "structlog (>=25.3.0,<26.0.0)",
     "uvicorn (>=0.34.2,<0.35.0)",
-    "polars (>=1.30.0,<2.0.0)"
+    "polars (>=1.30.0,<2.0.0)",
+    "httpx (>=0.28.1,<0.29.0)"
 ]
 
 [tool.poetry]

--- a/tests/data/synthetic_experiments.json
+++ b/tests/data/synthetic_experiments.json
@@ -1,0 +1,214 @@
+{
+    "experiments": [
+        {
+            "id": "MS002001-01",
+            "study_type": "Transcriptomics",
+            "experiment_type": "RNA-Seq",
+            "experiment_ontology": [
+                {
+                    "id": "OBI:0001177",
+                    "label": "RNA sequencing assay"
+                }
+            ],
+            "library_strategy": "RNA-Seq",
+            "library_source": "Transcriptomic",
+            "library_selection": "Random PCR",
+            "molecule": "total RNA",
+            "molecule_ontology": [
+                {
+                    "id": "EFO:0004964",
+                    "label": "total RNA"
+                }
+            ],
+            "biosample": "MS002001",
+            "experiment_results": [
+                {
+                    "identifier": "MS002001-01-00",
+                    "description": "RNAseq alignment, forward signal",
+                    "filename": "51570.CEEHRC.MS002001.RNA-Seq.signal_forward.bigWig",
+                    "url": "https://epigenomesportal.ca/tracks/CEEHRC/hg19/51570.CEEHRC.MS002001.RNA-Seq.signal_forward.bigWig",
+                    "file_format": "BigWig",
+                    "genome_assembly_id": "GRCh37",
+                    "data_output_type": "Derived data",
+                    "creation_date": "2022-02-08 00:00:00"
+                },
+                {
+                    "identifier": "MS002001-01-01",
+                    "description": "RNAseq alignment, reverse signal",
+                    "filename": "51571.CEEHRC.MS002001.RNA-Seq.signal_reverse.bigWig",
+                    "url": "https://epigenomesportal.ca/tracks/CEEHRC/hg19/51571.CEEHRC.MS002001.RNA-Seq.signal_reverse.bigWig",
+                    "file_format": "BigWig",
+                    "genome_assembly_id": "GRCh37",
+                    "data_output_type": "Derived data",
+                    "creation_date": "2022-02-08 00:00:00"
+                }
+            ]
+        },
+        {
+            "id": "0ba18733-40a8-4e86-b93b-a660f00241e9",
+            "biosample": "McGill0020-1",
+            "study_type": "Other",
+            "experiment_type": "Other",
+            "experiment_ontology": [
+                {
+                    "id": "OBI:0000537",
+                    "label": "copy number variation profiling assay"
+                }
+            ]
+        },
+        {
+            "id": "MS002201-01",
+            "study_type": "Transcriptomics",
+            "experiment_type": "RNA-Seq",
+            "experiment_ontology": [
+                {
+                    "id": "OBI:0001177",
+                    "label": "RNA sequencing assay"
+                }
+            ],
+            "library_source": "Transcriptomic",
+            "library_strategy": "RNA-Seq",
+            "library_selection": "Random PCR",
+            "molecule": "total RNA",
+            "molecule_ontology": [
+                {
+                    "id": "EFO:0004964",
+                    "label": "total RNA"
+                }
+            ],
+            "biosample": "MS002201",
+            "experiment_results": [
+                {
+                    "identifier": "MS002201-01-00",
+                    "description": "RNAseq alignment, forward signal",
+                    "filename": "51598.CEEHRC.MS002201.RNA-Seq.signal_forward.bigWig",
+                    "url": "https://epigenomesportal.ca/tracks/CEEHRC/hg19/51598.CEEHRC.MS002201.RNA-Seq.signal_forward.bigWig",
+                    "file_format": "BigWig",
+                    "genome_assembly_id": "GRCh37",
+                    "data_output_type": "Derived data",
+                    "creation_date": "2022-02-08 00:00:00"
+                }
+            ]
+        },
+        {
+            "id": "c1e494c6-e805-4300-823b-36a4ef9c9c24",
+            "biosample": "FAKE-003-0",
+            "study_type": "Metabolomics",
+            "experiment_type": "Metabolite profiling",
+            "experiment_ontology": [
+                {
+                    "id": "OBI:0000366",
+                    "label": "metabolite profiling assay"
+                }
+            ],
+            "experiment_results": [
+                {
+                    "identifier": "c16d16b5-6edf-495f-8b59-61760eb64944",
+                    "usage": "Downloaded",
+                    "created_by": "C3G_synthetic_data",
+                    "filename": "example.docx",
+                    "file_format": "DOCX"
+                }
+            ]
+        },
+        {
+            "id": "a5e69c87-24fd-4903-8b6f-76c418c9ed76",
+            "biosample": "FAKE-004-0",
+            "study_type": "Other",
+            "experiment_type": "Other",
+            "experiment_ontology": [
+                {
+                    "id": "OBI:0000537",
+                    "label": "copy number variation profiling assay"
+                }
+            ]
+        },
+        {
+            "id": "491d7073-6796-4609-98ce-1aa664ca33c8",
+            "biosample": "FAKE-005-1",
+            "study_type": "Other",
+            "experiment_type": "Other",
+            "experiment_ontology": [
+                {
+                    "id": "OBI:0003172",
+                    "label": "thyroid stimulating hormone concentration assay"
+                }
+            ]
+        },
+        {
+            "id": "e4960450-acce-45a7-810c-db68fc89ab0c",
+            "biosample": "FAKE-008-0",
+            "study_type": "Other",
+            "experiment_type": "Other",
+            "experiment_ontology": [
+                {
+                    "id": "OBI:0000537",
+                    "label": "copy number variation profiling assay"
+                }
+            ],
+            "experiment_results": [
+                {
+                    "identifier": "2580b225-d688-4f53-bccc-5608ef7525d2",
+                    "usage": "Downloaded",
+                    "created_by": "C3G_synthetic_data",
+                    "filename": "example.md",
+                    "file_format": "MARKDOWN"
+                }
+            ]
+        },
+        {
+            "id": "e685e4af-0a43-411f-ba76-e698d60f955d",
+            "biosample": "FAKE-009-0",
+            "study_type": "Other",
+            "experiment_type": "Other",
+            "experiment_ontology": [
+                {
+                    "id": "OBI:0000537",
+                    "label": "copy number variation profiling assay"
+                }
+            ]
+        },
+        {
+            "id": "3781684b-401f-4082-b367-6885d841def1",
+            "biosample": "FAKE-011-0",
+            "study_type": "Other",
+            "experiment_type": "Other",
+            "experiment_ontology": [
+                {
+                    "id": "OBI:0000537",
+                    "label": "copy number variation profiling assay"
+                }
+            ]
+        },
+        {
+            "id": "ce341086-a627-4be3-b847-99f06c3b5dc2",
+            "biosample": "FAKE-015-0",
+            "study_type": "Other",
+            "experiment_type": "Other",
+            "experiment_ontology": [
+                {
+                    "id": "OBI:0000537",
+                    "label": "copy number variation profiling assay"
+                }
+            ]
+        }
+    ],
+    "resources": [
+        {
+            "name": "Ontology for Biomedical Investigations",
+            "version": "2020-12-16",
+            "namespace_prefix": "OBI",
+            "id": "OBI:2020-12-16",
+            "iri_prefix": "http://purl.obolibrary.org/obo/OBI_",
+            "url": "http://purl.obolibrary.org/obo/obi.owl"
+        },
+        {
+            "name": "Experimental Factor Ontology",
+            "version": "2021-02-16",
+            "namespace_prefix": "EFO",
+            "id": "EFO:2021-02-16",
+            "iri_prefix": "http://www.ebi.ac.uk/efo/EFO_",
+            "url": "http://www.ebi.ac.uk/efo/releases/v3.27.0/efo.owl"
+        }
+    ]
+}

--- a/tests/data/synthetic_phenopackets_v2.json
+++ b/tests/data/synthetic_phenopackets_v2.json
@@ -1,0 +1,1161 @@
+[
+    {
+        "id": "51154a27-f523-40cc-87c9-8701f316389e",
+        "subject": {
+            "id": "McGill0020",
+            "sex": "MALE",
+            "time_at_last_encounter": {
+                "age": {
+                    "iso8601duration": "P30Y"
+                }
+            },
+            "taxonomy": {
+                "id": "NCBITaxon:9606",
+                "label": "Homo sapiens"
+            },
+            "karyotypic_sex": "XY",
+            "extra_properties": {
+                "mobility": "I have slight problems in walking about",
+                "covid_severity": "Uninfected",
+                "date_of_consent": "2021-10-05",
+                "lab_test_result_value": 39,
+                "smoking_status": "Not specified"
+            }
+        },
+        "phenotypic_features": [
+            {
+                "type": {
+                    "id": "SNOMED:386661006",
+                    "label": "Fever"
+                }
+            },
+            {
+                "type": {
+                    "id": "SNOMED:52448006",
+                    "label": "Dementia"
+                }
+            }
+        ],
+        "biosamples": [
+            {
+                "id": "MS002001",
+                "sampled_tissue": {
+                    "id": "UBERON:0000955",
+                    "label": "Brodmann (1909) area 11"
+                },
+                "procedure": {
+                    "code": {
+                        "id": "NCIT:C15189",
+                        "label": "Biopsy"
+                    }
+                }
+            },
+            {
+                "id": "McGill0020-0"
+            },
+            {
+                "id": "McGill0020-1"
+            },
+            {
+                "id": "McGill0020-2",
+                "sampled_tissue": {
+                    "id": "NCIT:C13325",
+                    "label": "Serum"
+                }
+            }
+        ],
+        "measurements": [
+            {
+                "assay": {
+                    "id": "NCIT:C16358",
+                    "label": "Body Mass Index"
+                },
+                "value": {
+                    "quantity": {
+                        "unit": {
+                            "id": "NCIT:C49671",
+                            "label": "Kilogram per Square Meter"
+                        },
+                        "value": 20.49
+                    }
+                }
+            },
+            {
+                "assay": {
+                    "id": "NCIT:C167233",
+                    "label": "Blood Pressure Measurement"
+                },
+                "complex_value": {
+                    "typed_quantities": [
+                        {
+                            "type": {
+                                "id": "NCIT:C25298",
+                                "label": "Systolic Blood Pressure"
+                            },
+                            "quantity": {
+                                "unit": {
+                                    "id": "NCIT:C49670",
+                                    "label": "Millimeter of Mercury"
+                                },
+                                "value": 152
+                            }
+                        },
+                        {
+                            "type": {
+                                "id": "NCIT:C25299",
+                                "label": "Diastolic Blood Pressure"
+                            },
+                            "quantity": {
+                                "unit": {
+                                    "id": "NCIT:C49670",
+                                    "label": "Millimeter of Mercury"
+                                },
+                                "value": 132
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "medical_actions": [
+            {
+                "treatment": {
+                    "agent": {
+                        "id": "NCIT:C1119",
+                        "label": "Ondansetron"
+                    }
+                },
+                "treatment_target": {
+                    "id": "NCIT:C3258",
+                    "label": "Nausea"
+                },
+                "adverse_events": [
+                    {
+                        "id": "NCIT:C3038",
+                        "label": "Fever"
+                    }
+                ]
+            }
+        ],
+        "interpretations": [
+            {
+                "id": "McGill0020-interpretation-000",
+                "progress_status": "UNKNOWN_PROGRESS",
+                "summary": "diagnosis in progress"
+            }
+        ],
+        "diseases": [
+            {
+                "term": {
+                    "id": "MONDO:0012011",
+                    "label": "coronary artery disease, autosomal dominant, 1"
+                }
+            },
+            {
+                "term": {
+                    "id": "SNOMED:85828009",
+                    "label": "Rheumatologic disease"
+                }
+            }
+        ],
+        "meta_data": {
+            "created": "2025-02-20T15:28:17+00:00",
+            "created_by": "C3G_synthetic_data",
+            "phenopacket_schema_version": "2.0",
+            "resources": [
+                {
+                    "name": "NCBI Taxonomy OBO Edition",
+                    "version": "2023-09-19",
+                    "namespace_prefix": "NCBITaxon",
+                    "id": "NCBITaxon:2023-09-19",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/NCBITaxon_",
+                    "url": "http://purl.obolibrary.org/obo/ncbitaxon/2023-09-19/ncbitaxon.owl"
+                },
+                {
+                    "id": "UBERON:2019-06-27",
+                    "name": "Uber-anatomy ontology",
+                    "namespace_prefix": "UBERON",
+                    "url": "http://purl.obolibrary.org/obo/uberon.owl",
+                    "version": "2019-06-27",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/UBERON_"
+                },
+                {
+                    "name": "National Cancer Institute Thesaurus",
+                    "version": "2021-02-12",
+                    "namespace_prefix": "NCIT",
+                    "id": "NCIT:2021-02-12",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/NCIT_",
+                    "url": "http://purl.obolibrary.org/obo/ncit/releases/2021-02-12/ncit.owl"
+                },
+                {
+                    "name": "GENO ontology",
+                    "version": "2023-10-08",
+                    "namespace_prefix": "GENO",
+                    "id": "GENO:2023-10-08",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/GENO_",
+                    "url": "http://purl.obolibrary.org/obo/geno/releases/2023-10-08/geno.owl"
+                },
+                {
+                    "name": "The Human Phenotype Ontology",
+                    "version": "2023-09-01",
+                    "namespace_prefix": "HP",
+                    "id": "HP:2023-09-01",
+                    "iri_prefix": "https://hpo.jax.org/app/browse/term/",
+                    "url": "http://purl.obolibrary.org/obo/hp/releases/2023-09-01/hp.owl"
+                },
+                {
+                    "name": "SNOMED Clinical Terms",
+                    "version": "2019-04-11",
+                    "namespace_prefix": "SNOMED",
+                    "id": "SNOMED:2019-04-11",
+                    "iri_prefix": "http://purl.bioontology.org/ontology/SNOMEDCT/",
+                    "url": "http://purl.bioontology.org/ontology/SNOMEDCT"
+                }
+            ]
+        }
+    },
+    {
+        "id": "b5a7f746-3a42-4d51-b05b-a72022c9d861",
+        "subject": {
+            "id": "McGill0022",
+            "sex": "FEMALE",
+            "time_at_last_encounter": {
+                "age": {
+                    "iso8601duration": "P60Y"
+                }
+            },
+            "taxonomy": {
+                "id": "NCBITaxon:9606",
+                "label": "Homo sapiens"
+            },
+            "karyotypic_sex": "XX",
+            "extra_properties": {
+                "mobility": "I have no problems in walking about",
+                "covid_severity": "Moderate",
+                "date_of_consent": "2023-08-23",
+                "lab_test_result_value": 9,
+                "smoking_status": "Non-smoker"
+            }
+        },
+        "phenotypic_features": [],
+        "biosamples": [
+            {
+                "id": "MS002201",
+                "sampled_tissue": {
+                    "id": "NCIT:C12415",
+                    "label": "Kidney"
+                },
+                "histological_diagnosis": {
+                    "id": "NCIT:C9384",
+                    "label": "Renal Carcinoma"
+                },
+                "procedure": {
+                    "code": {
+                        "id": "NCIT:C15189",
+                        "label": "Biopsy"
+                    }
+                }
+            }
+        ],
+        "measurements": [
+            {
+                "assay": {
+                    "id": "NCIT:C16358",
+                    "label": "Body Mass Index"
+                },
+                "value": {
+                    "quantity": {
+                        "unit": {
+                            "id": "NCIT:C49671",
+                            "label": "Kilogram per Square Meter"
+                        },
+                        "value": 27.15
+                    }
+                }
+            },
+            {
+                "assay": {
+                    "id": "NCIT:C167233",
+                    "label": "Blood Pressure Measurement"
+                },
+                "complex_value": {
+                    "typed_quantities": [
+                        {
+                            "type": {
+                                "id": "NCIT:C25298",
+                                "label": "Systolic Blood Pressure"
+                            },
+                            "quantity": {
+                                "unit": {
+                                    "id": "NCIT:C49670",
+                                    "label": "Millimeter of Mercury"
+                                },
+                                "value": 135
+                            }
+                        },
+                        {
+                            "type": {
+                                "id": "NCIT:C25299",
+                                "label": "Diastolic Blood Pressure"
+                            },
+                            "quantity": {
+                                "unit": {
+                                    "id": "NCIT:C49670",
+                                    "label": "Millimeter of Mercury"
+                                },
+                                "value": 97
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "medical_actions": [
+            {
+                "procedure": {
+                    "code": {
+                        "id": "NCIT:C17007",
+                        "label": "Positron Emission Tomography"
+                    }
+                },
+                "treatment_intent": {
+                    "id": "NCIT:C15220",
+                    "label": "Diagnosis"
+                },
+                "adverse_events": [
+                    {
+                        "id": "NCIT:C3258",
+                        "label": "Nausea"
+                    },
+                    {
+                        "id": "NCIT:C39594",
+                        "label": "Skin Rash"
+                    }
+                ],
+                "treatment_target": {
+                    "id": "NCIT:C34660",
+                    "label": "Head Injury"
+                }
+            },
+            {
+                "procedure": {
+                    "code": {
+                        "id": "NCIT:C16809",
+                        "label": "Magnetic Resonance Imaging"
+                    }
+                }
+            },
+            {
+                "treatment": {
+                    "agent": {
+                        "id": "NCIT:C198",
+                        "label": "Acetaminophen"
+                    },
+                    "route_of_administration": {
+                        "id": "NCIT:C38288",
+                        "label": "Oral Route of Administration"
+                    },
+                    "dose_intervals": [
+                        {
+                            "quantity": {
+                                "unit": {
+                                    "id": "UO:0000022",
+                                    "label": "milligram"
+                                },
+                                "value": 500
+                            },
+                            "schedule_frequency": {
+                                "id": "NCIT:C64496",
+                                "label": "Twice Daily"
+                            },
+                            "interval": {
+                                "start": "2023-10-04T06:31:41+00:00",
+                                "end": "2023-10-18T06:31:41+00:00"
+                            }
+                        }
+                    ],
+                    "drug_type": "PRESCRIPTION"
+                },
+                "treatment_target": {
+                    "id": "NCIT:C34661",
+                    "label": "Headache"
+                }
+            },
+            {
+                "treatment": {
+                    "agent": {
+                        "id": "NCIT:C1119",
+                        "label": "Ondansetron"
+                    }
+                },
+                "treatment_target": {
+                    "id": "NCIT:C3258",
+                    "label": "Nausea"
+                },
+                "adverse_events": [
+                    {
+                        "id": "NCIT:C3038",
+                        "label": "Fever"
+                    }
+                ]
+            },
+            {
+                "treatment": {
+                    "agent": {
+                        "id": "NCIT:C561",
+                        "label": "Ibuprofen"
+                    },
+                    "route_of_administration": {
+                        "id": "NCIT:C38288",
+                        "label": "Oral Route of Administration"
+                    },
+                    "dose_intervals": [
+                        {
+                            "quantity": {
+                                "unit": {
+                                    "id": "UO:0000022",
+                                    "label": "milligram"
+                                },
+                                "value": 500
+                            },
+                            "schedule_frequency": {
+                                "id": "NCIT:C64496",
+                                "label": "Twice Daily"
+                            },
+                            "interval": {
+                                "start": "2023-10-04T06:31:41+00:00",
+                                "end": "2023-10-18T06:31:41+00:00"
+                            }
+                        }
+                    ],
+                    "drug_type": "PRESCRIPTION"
+                }
+            }
+        ],
+        "diseases": [
+            {
+                "term": {
+                    "id": "NCIT:C9384",
+                    "label": "Renal Carcinoma"
+                },
+                "onset": {
+                    "timestamp": "2020-03-17T00:00:00Z"
+                }
+            },
+            {
+                "term": {
+                    "id": "SNOMED:840539006",
+                    "label": "COVID-19"
+                }
+            }
+        ],
+        "meta_data": {
+            "created": "2025-02-20T15:28:17+00:00",
+            "created_by": "C3G_synthetic_data",
+            "phenopacket_schema_version": "2.0",
+            "resources": [
+                {
+                    "name": "NCBI Taxonomy OBO Edition",
+                    "version": "2023-09-19",
+                    "namespace_prefix": "NCBITaxon",
+                    "id": "NCBITaxon:2023-09-19",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/NCBITaxon_",
+                    "url": "http://purl.obolibrary.org/obo/ncbitaxon/2023-09-19/ncbitaxon.owl"
+                },
+                {
+                    "id": "UBERON:2019-06-27",
+                    "name": "Uber-anatomy ontology",
+                    "namespace_prefix": "UBERON",
+                    "url": "http://purl.obolibrary.org/obo/uberon.owl",
+                    "version": "2019-06-27",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/UBERON_"
+                },
+                {
+                    "name": "National Cancer Institute Thesaurus",
+                    "version": "2021-02-12",
+                    "namespace_prefix": "NCIT",
+                    "id": "NCIT:2021-02-12",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/NCIT_",
+                    "url": "http://purl.obolibrary.org/obo/ncit/releases/2021-02-12/ncit.owl"
+                },
+                {
+                    "name": "GENO ontology",
+                    "version": "2023-10-08",
+                    "namespace_prefix": "GENO",
+                    "id": "GENO:2023-10-08",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/GENO_",
+                    "url": "http://purl.obolibrary.org/obo/geno/releases/2023-10-08/geno.owl"
+                },
+                {
+                    "name": "The Human Phenotype Ontology",
+                    "version": "2023-09-01",
+                    "namespace_prefix": "HP",
+                    "id": "HP:2023-09-01",
+                    "iri_prefix": "https://hpo.jax.org/app/browse/term/",
+                    "url": "http://purl.obolibrary.org/obo/hp/releases/2023-09-01/hp.owl"
+                },
+                {
+                    "name": "SNOMED Clinical Terms",
+                    "version": "2019-04-11",
+                    "namespace_prefix": "SNOMED",
+                    "id": "SNOMED:2019-04-11",
+                    "iri_prefix": "http://purl.bioontology.org/ontology/SNOMEDCT/",
+                    "url": "http://purl.bioontology.org/ontology/SNOMEDCT"
+                }
+            ]
+        }
+    },
+    {
+        "id": "efd61faa-bff9-4467-a132-f383dc00eba3",
+        "subject": {
+            "id": "FAKE-001",
+            "sex": "MALE",
+            "time_at_last_encounter": {
+                "age": {
+                    "iso8601duration": "P32Y"
+                }
+            },
+            "taxonomy": {
+                "id": "NCBITaxon:9606",
+                "label": "Homo sapiens"
+            },
+            "karyotypic_sex": "XY",
+            "extra_properties": {
+                "mobility": "I am unable to walk about",
+                "covid_severity": "Moderate",
+                "date_of_consent": "2022-04-30",
+                "lab_test_result_value": 128,
+                "smoking_status": "Non-smoker"
+            }
+        },
+        "phenotypic_features": [],
+        "measurements": [
+            {
+                "assay": {
+                    "id": "NCIT:C16358",
+                    "label": "Body Mass Index"
+                },
+                "value": {
+                    "quantity": {
+                        "unit": {
+                            "id": "NCIT:C49671",
+                            "label": "Kilogram per Square Meter"
+                        },
+                        "value": 23.46
+                    }
+                }
+            },
+            {
+                "assay": {
+                    "id": "NCIT:C167233",
+                    "label": "Blood Pressure Measurement"
+                },
+                "complex_value": {
+                    "typed_quantities": [
+                        {
+                            "type": {
+                                "id": "NCIT:C25298",
+                                "label": "Systolic Blood Pressure"
+                            },
+                            "quantity": {
+                                "unit": {
+                                    "id": "NCIT:C49670",
+                                    "label": "Millimeter of Mercury"
+                                },
+                                "value": 111
+                            }
+                        },
+                        {
+                            "type": {
+                                "id": "NCIT:C25299",
+                                "label": "Diastolic Blood Pressure"
+                            },
+                            "quantity": {
+                                "unit": {
+                                    "id": "NCIT:C49670",
+                                    "label": "Millimeter of Mercury"
+                                },
+                                "value": 79
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "medical_actions": [
+            {
+                "procedure": {
+                    "code": {
+                        "id": "NCIT:C17007",
+                        "label": "Positron Emission Tomography"
+                    }
+                },
+                "treatment_intent": {
+                    "id": "NCIT:C15220",
+                    "label": "Diagnosis"
+                },
+                "adverse_events": [
+                    {
+                        "id": "NCIT:C3258",
+                        "label": "Nausea"
+                    },
+                    {
+                        "id": "NCIT:C39594",
+                        "label": "Skin Rash"
+                    }
+                ],
+                "treatment_target": {
+                    "id": "NCIT:C34660",
+                    "label": "Head Injury"
+                }
+            },
+            {
+                "procedure": {
+                    "code": {
+                        "id": "NCIT:C38101",
+                        "label": "X-Ray Imaging"
+                    }
+                }
+            },
+            {
+                "procedure": {
+                    "code": {
+                        "id": "NCIT:C16809",
+                        "label": "Magnetic Resonance Imaging"
+                    }
+                }
+            }
+        ],
+        "diseases": [
+            {
+                "term": {
+                    "id": "SNOMED:840539006",
+                    "label": "COVID-19"
+                }
+            }
+        ],
+        "meta_data": {
+            "created": "2025-02-20T15:28:17+00:00",
+            "created_by": "C3G_synthetic_data",
+            "phenopacket_schema_version": "2.0",
+            "resources": [
+                {
+                    "name": "NCBI Taxonomy OBO Edition",
+                    "version": "2023-09-19",
+                    "namespace_prefix": "NCBITaxon",
+                    "id": "NCBITaxon:2023-09-19",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/NCBITaxon_",
+                    "url": "http://purl.obolibrary.org/obo/ncbitaxon/2023-09-19/ncbitaxon.owl"
+                },
+                {
+                    "id": "UBERON:2019-06-27",
+                    "name": "Uber-anatomy ontology",
+                    "namespace_prefix": "UBERON",
+                    "url": "http://purl.obolibrary.org/obo/uberon.owl",
+                    "version": "2019-06-27",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/UBERON_"
+                },
+                {
+                    "name": "National Cancer Institute Thesaurus",
+                    "version": "2021-02-12",
+                    "namespace_prefix": "NCIT",
+                    "id": "NCIT:2021-02-12",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/NCIT_",
+                    "url": "http://purl.obolibrary.org/obo/ncit/releases/2021-02-12/ncit.owl"
+                },
+                {
+                    "name": "GENO ontology",
+                    "version": "2023-10-08",
+                    "namespace_prefix": "GENO",
+                    "id": "GENO:2023-10-08",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/GENO_",
+                    "url": "http://purl.obolibrary.org/obo/geno/releases/2023-10-08/geno.owl"
+                },
+                {
+                    "name": "The Human Phenotype Ontology",
+                    "version": "2023-09-01",
+                    "namespace_prefix": "HP",
+                    "id": "HP:2023-09-01",
+                    "iri_prefix": "https://hpo.jax.org/app/browse/term/",
+                    "url": "http://purl.obolibrary.org/obo/hp/releases/2023-09-01/hp.owl"
+                },
+                {
+                    "name": "SNOMED Clinical Terms",
+                    "version": "2019-04-11",
+                    "namespace_prefix": "SNOMED",
+                    "id": "SNOMED:2019-04-11",
+                    "iri_prefix": "http://purl.bioontology.org/ontology/SNOMEDCT/",
+                    "url": "http://purl.bioontology.org/ontology/SNOMEDCT"
+                }
+            ]
+        }
+    },
+    {
+        "id": "d24c03a2-0d29-4c68-acfb-a1dba27fc801",
+        "subject": {
+            "id": "FAKE-002",
+            "sex": "MALE",
+            "time_at_last_encounter": {
+                "age": {
+                    "iso8601duration": "P50Y"
+                }
+            },
+            "taxonomy": {
+                "id": "NCBITaxon:9606",
+                "label": "Homo sapiens"
+            },
+            "karyotypic_sex": "XY",
+            "extra_properties": {
+                "mobility": "I am unable to walk about",
+                "covid_severity": "Uninfected",
+                "date_of_consent": "2020-05-02",
+                "lab_test_result_value": 129,
+                "smoking_status": "Smoker"
+            }
+        },
+        "phenotypic_features": [
+            {
+                "type": {
+                    "id": "SNOMED:410429000",
+                    "label": "Cardiac arrest"
+                }
+            },
+            {
+                "type": {
+                    "id": "SNOMED:25064002",
+                    "label": "Headache"
+                }
+            }
+        ],
+        "measurements": [
+            {
+                "assay": {
+                    "id": "NCIT:C16358",
+                    "label": "Body Mass Index"
+                },
+                "value": {
+                    "quantity": {
+                        "unit": {
+                            "id": "NCIT:C49671",
+                            "label": "Kilogram per Square Meter"
+                        },
+                        "value": 18.27
+                    }
+                }
+            }
+        ],
+        "medical_actions": [
+            {
+                "procedure": {
+                    "code": {
+                        "id": "NCIT:C51677",
+                        "label": "Liver Biopsy"
+                    },
+                    "body_site": {
+                        "id": "UBERON:0001115",
+                        "label": "left lobe of liver"
+                    }
+                }
+            }
+        ],
+        "diseases": [
+            {
+                "term": {
+                    "id": "NCIT:C27191",
+                    "label": "Hashimoto Thyroiditis"
+                }
+            }
+        ],
+        "meta_data": {
+            "created": "2025-02-20T15:28:17+00:00",
+            "created_by": "C3G_synthetic_data",
+            "phenopacket_schema_version": "2.0",
+            "resources": [
+                {
+                    "name": "NCBI Taxonomy OBO Edition",
+                    "version": "2023-09-19",
+                    "namespace_prefix": "NCBITaxon",
+                    "id": "NCBITaxon:2023-09-19",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/NCBITaxon_",
+                    "url": "http://purl.obolibrary.org/obo/ncbitaxon/2023-09-19/ncbitaxon.owl"
+                },
+                {
+                    "id": "UBERON:2019-06-27",
+                    "name": "Uber-anatomy ontology",
+                    "namespace_prefix": "UBERON",
+                    "url": "http://purl.obolibrary.org/obo/uberon.owl",
+                    "version": "2019-06-27",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/UBERON_"
+                },
+                {
+                    "name": "National Cancer Institute Thesaurus",
+                    "version": "2021-02-12",
+                    "namespace_prefix": "NCIT",
+                    "id": "NCIT:2021-02-12",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/NCIT_",
+                    "url": "http://purl.obolibrary.org/obo/ncit/releases/2021-02-12/ncit.owl"
+                },
+                {
+                    "name": "GENO ontology",
+                    "version": "2023-10-08",
+                    "namespace_prefix": "GENO",
+                    "id": "GENO:2023-10-08",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/GENO_",
+                    "url": "http://purl.obolibrary.org/obo/geno/releases/2023-10-08/geno.owl"
+                },
+                {
+                    "name": "The Human Phenotype Ontology",
+                    "version": "2023-09-01",
+                    "namespace_prefix": "HP",
+                    "id": "HP:2023-09-01",
+                    "iri_prefix": "https://hpo.jax.org/app/browse/term/",
+                    "url": "http://purl.obolibrary.org/obo/hp/releases/2023-09-01/hp.owl"
+                },
+                {
+                    "name": "SNOMED Clinical Terms",
+                    "version": "2019-04-11",
+                    "namespace_prefix": "SNOMED",
+                    "id": "SNOMED:2019-04-11",
+                    "iri_prefix": "http://purl.bioontology.org/ontology/SNOMEDCT/",
+                    "url": "http://purl.bioontology.org/ontology/SNOMEDCT"
+                }
+            ]
+        }
+    },
+    {
+        "id": "68b4c6a9-bf3e-483c-aba8-f4a05a062f07",
+        "subject": {
+            "id": "FAKE-003",
+            "sex": "MALE",
+            "time_at_last_encounter": {
+                "age": {
+                    "iso8601duration": "P78Y"
+                }
+            },
+            "taxonomy": {
+                "id": "NCBITaxon:9606",
+                "label": "Homo sapiens"
+            },
+            "karyotypic_sex": "XY",
+            "extra_properties": {
+                "mobility": "I have slight problems in walking about",
+                "covid_severity": "Moderate",
+                "date_of_consent": "2020-12-11",
+                "lab_test_result_value": 30,
+                "smoking_status": "Non-smoker"
+            }
+        },
+        "phenotypic_features": [],
+        "biosamples": [
+            {
+                "id": "FAKE-003-0",
+                "sampled_tissue": {
+                    "id": "NCIT:C13356",
+                    "label": "Plasma"
+                }
+            }
+        ],
+        "measurements": [
+            {
+                "assay": {
+                    "id": "NCIT:C16358",
+                    "label": "Body Mass Index"
+                },
+                "value": {
+                    "quantity": {
+                        "unit": {
+                            "id": "NCIT:C49671",
+                            "label": "Kilogram per Square Meter"
+                        },
+                        "value": 29.89
+                    }
+                }
+            }
+        ],
+        "interpretations": [
+            {
+                "id": "FAKE-003-interpretation:001",
+                "progress_status": "SOLVED",
+                "diagnosis": {
+                    "disease": {
+                        "id": "SNOMED:66038001",
+                        "label": "Miller syndrome"
+                    },
+                    "genomic_interpretations": [
+                        {
+                            "subject_or_biosample_id": "FAKE-003",
+                            "interpretation_status": "CONTRIBUTORY",
+                            "gene_descriptor": {
+                                "value_id": "HGNC:2867",
+                                "symbol": "DHODH"
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "diseases": [
+            {
+                "term": {
+                    "id": "SNOMED:66038001",
+                    "label": "Miller syndrome"
+                }
+            },
+            {
+                "term": {
+                    "id": "SNOMED:840539006",
+                    "label": "COVID-19"
+                }
+            }
+        ],
+        "meta_data": {
+            "created": "2025-02-20T15:28:17+00:00",
+            "created_by": "C3G_synthetic_data",
+            "phenopacket_schema_version": "2.0",
+            "resources": [
+                {
+                    "name": "NCBI Taxonomy OBO Edition",
+                    "version": "2023-09-19",
+                    "namespace_prefix": "NCBITaxon",
+                    "id": "NCBITaxon:2023-09-19",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/NCBITaxon_",
+                    "url": "http://purl.obolibrary.org/obo/ncbitaxon/2023-09-19/ncbitaxon.owl"
+                },
+                {
+                    "id": "UBERON:2019-06-27",
+                    "name": "Uber-anatomy ontology",
+                    "namespace_prefix": "UBERON",
+                    "url": "http://purl.obolibrary.org/obo/uberon.owl",
+                    "version": "2019-06-27",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/UBERON_"
+                },
+                {
+                    "name": "National Cancer Institute Thesaurus",
+                    "version": "2021-02-12",
+                    "namespace_prefix": "NCIT",
+                    "id": "NCIT:2021-02-12",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/NCIT_",
+                    "url": "http://purl.obolibrary.org/obo/ncit/releases/2021-02-12/ncit.owl"
+                },
+                {
+                    "name": "GENO ontology",
+                    "version": "2023-10-08",
+                    "namespace_prefix": "GENO",
+                    "id": "GENO:2023-10-08",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/GENO_",
+                    "url": "http://purl.obolibrary.org/obo/geno/releases/2023-10-08/geno.owl"
+                },
+                {
+                    "name": "The Human Phenotype Ontology",
+                    "version": "2023-09-01",
+                    "namespace_prefix": "HP",
+                    "id": "HP:2023-09-01",
+                    "iri_prefix": "https://hpo.jax.org/app/browse/term/",
+                    "url": "http://purl.obolibrary.org/obo/hp/releases/2023-09-01/hp.owl"
+                },
+                {
+                    "name": "SNOMED Clinical Terms",
+                    "version": "2019-04-11",
+                    "namespace_prefix": "SNOMED",
+                    "id": "SNOMED:2019-04-11",
+                    "iri_prefix": "http://purl.bioontology.org/ontology/SNOMEDCT/",
+                    "url": "http://purl.bioontology.org/ontology/SNOMEDCT"
+                }
+            ]
+        }
+    },
+    {
+        "id": "bb724a87-d13d-4d3c-9a80-fd7f32dce00c",
+        "subject": {
+            "id": "FAKE-004",
+            "sex": "MALE",
+            "time_at_last_encounter": {
+                "age": {
+                    "iso8601duration": "P95Y"
+                }
+            },
+            "taxonomy": {
+                "id": "NCBITaxon:9606",
+                "label": "Homo sapiens"
+            },
+            "karyotypic_sex": "XY",
+            "extra_properties": {
+                "mobility": "I have no problems in walking about",
+                "covid_severity": "Uninfected",
+                "date_of_consent": "2023-02-26",
+                "lab_test_result_value": 21
+            }
+        },
+        "phenotypic_features": [
+            {
+                "type": {
+                    "id": "SNOMED:195967001",
+                    "label": "Asthma"
+                }
+            }
+        ],
+        "biosamples": [
+            {
+                "id": "FAKE-004-0"
+            }
+        ],
+        "medical_actions": [
+            {
+                "treatment": {
+                    "agent": {
+                        "id": "NCIT:C1119",
+                        "label": "Ondansetron"
+                    }
+                },
+                "treatment_target": {
+                    "id": "NCIT:C3258",
+                    "label": "Nausea"
+                },
+                "adverse_events": [
+                    {
+                        "id": "NCIT:C3038",
+                        "label": "Fever"
+                    }
+                ]
+            },
+            {
+                "treatment": {
+                    "agent": {
+                        "id": "NCIT:C561",
+                        "label": "Ibuprofen"
+                    },
+                    "route_of_administration": {
+                        "id": "NCIT:C38288",
+                        "label": "Oral Route of Administration"
+                    },
+                    "dose_intervals": [
+                        {
+                            "quantity": {
+                                "unit": {
+                                    "id": "UO:0000022",
+                                    "label": "milligram"
+                                },
+                                "value": 500
+                            },
+                            "schedule_frequency": {
+                                "id": "NCIT:C64496",
+                                "label": "Twice Daily"
+                            },
+                            "interval": {
+                                "start": "2021-05-20T15:15:48+00:00",
+                                "end": "2021-06-01T15:15:48+00:00"
+                            }
+                        }
+                    ],
+                    "drug_type": "PRESCRIPTION"
+                }
+            },
+            {
+                "treatment": {
+                    "agent": {
+                        "id": "NCIT:C198",
+                        "label": "Acetaminophen"
+                    },
+                    "route_of_administration": {
+                        "id": "NCIT:C38288",
+                        "label": "Oral Route of Administration"
+                    },
+                    "dose_intervals": [
+                        {
+                            "quantity": {
+                                "unit": {
+                                    "id": "UO:0000022",
+                                    "label": "milligram"
+                                },
+                                "value": 500
+                            },
+                            "schedule_frequency": {
+                                "id": "NCIT:C64496",
+                                "label": "Twice Daily"
+                            },
+                            "interval": {
+                                "start": "2021-05-20T15:15:48+00:00",
+                                "end": "2021-06-01T15:15:48+00:00"
+                            }
+                        }
+                    ],
+                    "drug_type": "PRESCRIPTION"
+                },
+                "treatment_target": {
+                    "id": "NCIT:C34661",
+                    "label": "Headache"
+                }
+            }
+        ],
+        "interpretations": [
+            {
+                "id": "FAKE-004-interpretation-000",
+                "progress_status": "UNKNOWN_PROGRESS",
+                "summary": "diagnosis in progress"
+            }
+        ],
+        "diseases": [
+            {
+                "term": {
+                    "id": "MONDO:0012011",
+                    "label": "coronary artery disease, autosomal dominant, 1"
+                }
+            }
+        ],
+        "meta_data": {
+            "created": "2025-02-20T15:28:17+00:00",
+            "created_by": "C3G_synthetic_data",
+            "phenopacket_schema_version": "2.0",
+            "resources": [
+                {
+                    "name": "NCBI Taxonomy OBO Edition",
+                    "version": "2023-09-19",
+                    "namespace_prefix": "NCBITaxon",
+                    "id": "NCBITaxon:2023-09-19",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/NCBITaxon_",
+                    "url": "http://purl.obolibrary.org/obo/ncbitaxon/2023-09-19/ncbitaxon.owl"
+                },
+                {
+                    "id": "UBERON:2019-06-27",
+                    "name": "Uber-anatomy ontology",
+                    "namespace_prefix": "UBERON",
+                    "url": "http://purl.obolibrary.org/obo/uberon.owl",
+                    "version": "2019-06-27",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/UBERON_"
+                },
+                {
+                    "name": "National Cancer Institute Thesaurus",
+                    "version": "2021-02-12",
+                    "namespace_prefix": "NCIT",
+                    "id": "NCIT:2021-02-12",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/NCIT_",
+                    "url": "http://purl.obolibrary.org/obo/ncit/releases/2021-02-12/ncit.owl"
+                },
+                {
+                    "name": "GENO ontology",
+                    "version": "2023-10-08",
+                    "namespace_prefix": "GENO",
+                    "id": "GENO:2023-10-08",
+                    "iri_prefix": "http://purl.obolibrary.org/obo/GENO_",
+                    "url": "http://purl.obolibrary.org/obo/geno/releases/2023-10-08/geno.owl"
+                },
+                {
+                    "name": "The Human Phenotype Ontology",
+                    "version": "2023-09-01",
+                    "namespace_prefix": "HP",
+                    "id": "HP:2023-09-01",
+                    "iri_prefix": "https://hpo.jax.org/app/browse/term/",
+                    "url": "http://purl.obolibrary.org/obo/hp/releases/2023-09-01/hp.owl"
+                },
+                {
+                    "name": "SNOMED Clinical Terms",
+                    "version": "2019-04-11",
+                    "namespace_prefix": "SNOMED",
+                    "id": "SNOMED:2019-04-11",
+                    "iri_prefix": "http://purl.bioontology.org/ontology/SNOMEDCT/",
+                    "url": "http://purl.bioontology.org/ontology/SNOMEDCT"
+                }
+            ]
+        }
+    }
+]


### PR DESCRIPTION
Implement the first concrete Extractor class, that can be configured to poll an endpoint at a regular interval.
Also includes a test router that is only included when BENTO_DEBUG is true, this router's endpoints are intended to be used as a dummy data source endpoint for dev work.