### PR TITLE
Implement experiment loader

### DIFF
--- a/bento_etl/loaders/dependencies.py
+++ b/bento_etl/loaders/dependencies.py
@@ -2,6 +2,7 @@ from fastapi import Depends
 from typing import Annotated
 
 from bento_etl.loaders.base import BaseLoader
+from bento_etl.loaders.experiments_loader import ExperimentsLoader
 from bento_etl.loaders.phenopackets_loader import PhenopacketsLoader
 from bento_etl.logger import LoggerDependency
 from bento_etl.models import Job
@@ -14,6 +15,10 @@ def get_loader(job: Job, logger: LoggerDependency, config: ConfigDependency):
     # returns the appropriate loader instance depending on the job description
     if job.loader.data_type == "phenopackets":
         return PhenopacketsLoader(
+            logger, config, job.loader.dataset_id, job.loader.batch_size
+        )
+    elif job.loader.data_type == "experiments":
+        return ExperimentsLoader(
             logger, config, job.loader.dataset_id, job.loader.batch_size
         )
     else:

--- a/bento_etl/loaders/experiments_loader.py
+++ b/bento_etl/loaders/experiments_loader.py
@@ -1,0 +1,17 @@
+from logging import Logger
+
+from bento_etl.config import Config
+from .base import BaseLoader
+
+
+class ExperimentsLoader(BaseLoader):
+    def __init__(
+        self, logger: Logger, config: Config, dataset_id: str, batch_size: int = 0
+    ):
+        if not dataset_id:
+            raise ValueError("Dataset ID must be non-empty")
+        load_url = f"{config.katsu_url}ingest/{dataset_id}/experiments_json"
+        super().__init__(logger, config, load_url, "katsu", 204, batch_size)
+
+    async def load(self, data: list[dict]):
+        await self._load(data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,6 +87,15 @@ def load_phenopacket_data():
 
 
 @pytest.fixture
+def load_experiment_data():
+    caller_path = os.path.dirname(__file__)
+    file_path = os.path.join(caller_path, "data/synthetic_experiments.json")
+    with open(file_path) as f:
+        file_content = json.load(f)
+    return file_content
+
+
+@pytest.fixture
 def set_mock_for_valid_post(monkeypatch):
     async def mock_valid_post(*args, **kwargs):
         return httpx.Response(204)


### PR DESCRIPTION
Now that we can upload phenopackets to Katsu, it's time to add the logic to upload experiments as well